### PR TITLE
Create cross-platform Conda environment file

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,11 @@ First of all your will need `python3.6` installed (we currently only support **p
     ```
     Or you can install it from the source, head to `animalai/` folder and run `pip install -e .`
 
+    We also provide an `env.yml` by which you can install it via conda:
+    ```
+    conda env create -f env.yml
+    ```
+
 - We also provide a package that can be used as a starting point for training, and which is required to run most of the 
 example scripts found in the `examples/` folder. At the moment **we only support Linux and Max** for the training examples. It contains an extension of 
 [ml-agents' training environment](https://github.com/Unity-Technologies/ml-agents/tree/master/ml-agents) that relies on 

--- a/env.yml
+++ b/env.yml
@@ -1,0 +1,21 @@
+name: animal-ai
+channels:
+  - defaults
+  - conda-forge
+dependencies:
+  - python=3.6.*
+  - pip
+  - pillow>=4.2.1,<=5.4.1
+  - numpy>=1.13.3,<=1.14.5
+  - protobuf>=3.6,<3.7
+  - grpcio>=1.11.0,<1.12.0
+  - pyyaml>=5.1
+  - jsonpickle>=1.2
+  - pyglet>=1.2.0
+  - scipy
+  - cloudpickle=1.2.*
+  - future
+  - pip:
+    - gym
+    - animalai
+

--- a/env.yml
+++ b/env.yml
@@ -1,4 +1,4 @@
-name: animal-ai
+name: animalai
 channels:
   - defaults
   - conda-forge


### PR DESCRIPTION
This environment file is very convenient for Conda users to create an Pommerman environment by `conda env create -f env.yml`.

And Conda is much better because it can manage versions of Python and installation of CUDA toolkits.

This file is tested on Windows and Linux. And versions inside are consistent with those in `requirements.txt`.