### PR TITLE
fix curriculum order

### DIFF
--- a/examples/animalai_train/animalai_train/trainers/curriculum.py
+++ b/examples/animalai_train/animalai_train/trainers/curriculum.py
@@ -63,7 +63,7 @@ class Curriculum(object):
             raise Curriculum(
                 'One or more configuration file(s) in curriculum {0} could not be found'.format(location)
             )
-        self.configurations = [ArenaConfig(os.path.join(folder, file)) for file in yaml_files]
+        self.configurations = [ArenaConfig(os.path.join(folder, file)) for file in configuration_files]
 
     @property
     def lesson_num(self):
@@ -92,9 +92,10 @@ class Curriculum(object):
                 # parameters = self.data['parameters']
                 # for key in parameters:
                 #     config[key] = parameters[key][self.lesson_num]
-                logger.info('{0} lesson changed. Now in lesson {1}'
+                logger.info('{0} lesson changed. Now in lesson {1}: {2}'
                             .format(self._brain_name,
-                                    self.lesson_num))
+                                    self.lesson_num,
+                                    self.data['configuration_files'][self.lesson_num]))
                 return True
         return False
 


### PR DESCRIPTION
Hi! I think I found a minor bug.

List items in `yaml_files` are ordered by `os.listdir(curriculum_folder)` but I think they should be ordered by user settings in Learner.json (`self.data['configuration_files']`). So I fixed `yaml_files` to `configuration_files`.

Fortunately, in example curriculum settings, `os.listdir(curriculum_folder)` and `self.data['configuration_files']` are same but you can confirm this bug by Learner.json like,

```
{
  "measure": "reward",
  "thresholds": [
    -1.0,
    -1.0,
    -1.0,
    -1.0,
    -1.0
  ],
  "min_lesson_length": 1,
  "signal_smoothing": true,
  "configuration_files": [
    "5.yaml",
    "4.yaml",
    "3.yaml",
    "2.yaml",
    "1.yaml",
    "0.yaml"
  ]
}
```

It's expected to run from 5.yaml to 0.yaml but actually it runs from 0.yaml to 5.yaml. This patch should fix it. I also added a log item that shows configuration filename for convenience.

I'm really enjoying this competition! Thank you for organizing!
Susumu
